### PR TITLE
Removed .gitmodules

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,0 @@
-[submodule "submodules/stb"]
-	path = submodules/stb
-	url = https://github.com/nothings/stb.git
-[submodule "submodules/glfw"]
-	path = submodules/glfw
-	url = https://github.com/glfw/glfw.git


### PR DESCRIPTION
OWL no longer has any submodule dependencies, removed that erroneous left-over file.