### PR TITLE
bugfix for missing FindTBB.cmake install

### DIFF
--- a/.github/workflows/Ubuntu.yml
+++ b/.github/workflows/Ubuntu.yml
@@ -26,14 +26,6 @@ jobs:
             cuda: "13.0.2"
             gcc: 13
             config: Debug
-          - os: ubuntu-24.04
-            cuda: "12.6.0"
-            gcc: 13
-            config: Release
-          - os: ubuntu-24.04
-            cuda: "12.6.0"
-            gcc: 13
-            config: Debug
           - os: ubuntu-22.04
             cuda: "12.0.0"
             gcc: 11

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,7 +4,7 @@
 
 set(OWL_VERSION_MAJOR 1)
 set(OWL_VERSION_MINOR 2)
-set(OWL_VERSION_PATCH 3)
+set(OWL_VERSION_PATCH 4)
 
 cmake_minimum_required(VERSION 3.24)
 
@@ -153,7 +153,7 @@ install(DIRECTORY ${CMAKE_CURRENT_LIST_DIR}/cmake
     ${OWL_CMAKE_INSTALL_DESTINATION}
   FILES_MATCHING
     PATTERN *.cmake
-    PATTERN Findowl.cmake EXCLUDE
+    PATTERN FindTBB.cmake EXCLUDE
 )
 
 set(OWL_INSTALL_TARGETS owl owl_static)

--- a/owl/cmake/configure_tbb.cmake
+++ b/owl/cmake/configure_tbb.cmake
@@ -14,7 +14,7 @@ else()
  else()
    # on by default, because even if not installed it's trivial
    # to apt/yum install
-  OPTION(OWL_USE_TBB "Use TBB to parallelize host-side code?" ON)
+  OPTION(OWL_USE_TBB "Use TBB to parallelize host-side code?" OFF)
   endif()
 endif()
 

--- a/prime/include/owl/owl_prime.h
+++ b/prime/include/owl/owl_prime.h
@@ -1,7 +1,6 @@
-// SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA
+// CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
-
-
 
 #ifndef PRIMER_PRIMER_H
 #define PRIMER_PRIMER_H


### PR DESCRIPTION
This PR makes the install target also install the FindTBB script, which is required if the installed owl was built with tbb.
ALso bupms version to 1.2.4
