### PR TITLE
Fix operator precedence in SBTstride expression in owl_device.h

### DIFF
--- a/include/owl/owl_device.h
+++ b/include/owl/owl_device.h
@@ -173,7 +173,7 @@ namespace owl {
                ray.visibilityMask,
                /*rayFlags     */ rayFlags,
                /*SBToffset    */ ray.rayType,
-               /*SBTstride    */ ray.numRayTypes * (ray.disablePerGeometrySBTRecords) ? 0 : 1,
+               /*SBTstride    */ ray.numRayTypes * (ray.disablePerGeometrySBTRecords ? 0 : 1),
                /*missSBTIndex */ ray.rayType,              
                p0,
                p1);
@@ -228,7 +228,7 @@ namespace owl {
                ray.visibilityMask,
                /*rayFlags     */0u,
                /*SBToffset    */ray.rayType + numRayTypes*sbtOffset,
-               /*SBTstride    */numRayTypes * (ray.disablePerGeometrySBTRecords) ? 0 : 1,
+               /*SBTstride    */numRayTypes * (ray.disablePerGeometrySBTRecords ? 0 : 1),
                /*missSBTIndex */ray.rayType,
                p0,
                p1);

--- a/owl/deprecated-include/owl/owl_device.h
+++ b/owl/deprecated-include/owl/owl_device.h
@@ -173,7 +173,7 @@ namespace owl {
                ray.visibilityMask,
                /*rayFlags     */ rayFlags,
                /*SBToffset    */ ray.rayType,
-               /*SBTstride    */ ray.numRayTypes * (ray.disablePerGeometrySBTRecords) ? 0 : 1,
+               /*SBTstride    */ ray.numRayTypes * (ray.disablePerGeometrySBTRecords ? 0 : 1),
                /*missSBTIndex */ ray.rayType,              
                p0,
                p1);
@@ -228,7 +228,7 @@ namespace owl {
                ray.visibilityMask,
                /*rayFlags     */0u,
                /*SBToffset    */ray.rayType + numRayTypes*sbtOffset,
-               /*SBTstride    */numRayTypes * (ray.disablePerGeometrySBTRecords) ? 0 : 1,
+               /*SBTstride    */numRayTypes * (ray.disablePerGeometrySBTRecords ? 0 : 1),
                /*missSBTIndex */ray.rayType,
                p0,
                p1);


### PR DESCRIPTION
PR for Issue #18 
Operator precedence bug in the `SBTstride` argument of `optixTrace()` in `owl_device.h`. `*` binds tighter than `?:`, so the expression
```cpp
ray.numRayTypes * (ray.disablePerGeometrySBTRecords) ? 0 : 1
```
actually parses as (numRayTypes * disable) ? 0 : 1. The fix moves the parentheses around the ternary instead.

Same fix applied to the deprecated header copy in owl/deprecated-include/owl/owl_device.h for consistency.

Built and ran all 9 samples/cmdline samples on Windows (RTX 4060, CUDA 11.8, OptiX bundled, VS2022).

PNG output is byte-identical (SHA-256 match) before and after the fix on all 9 samples — expected because every bundled sample uses the default Ray = RayT<0, 1, false> where both expressions evaluate to the same SBTstride = 1.

Here is a visual confirmation for the fix, from my custom path tracer.

Settings: 2 ray types, multiple geometries in 1 GAS, `disablePerGeomtrySBTRecords==false`

Before: 
<img width="635" height="355" alt="image" src="https://github.com/user-attachments/assets/df38c572-2f35-4957-8a25-a9dbb66bd95a" />

After:
<img width="636" height="358" alt="image" src="https://github.com/user-attachments/assets/d466f230-3aa6-472d-b0c8-c786e0714d0e" />

