### PR TITLE
fixed compile issue for cuda 13.3

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,7 +4,7 @@
 
 set(OWL_VERSION_MAJOR 1)
 set(OWL_VERSION_MINOR 2)
-set(OWL_VERSION_PATCH 8)
+set(OWL_VERSION_PATCH 9)
 
 cmake_minimum_required(VERSION 3.24)
 

--- a/owl/Module.h
+++ b/owl/Module.h
@@ -1,11 +1,10 @@
-// SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA
+// CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
-
-
 
 #pragma once
 
-#include "RegisteredObject.h"
+#include "owl/RegisteredObject.h"
 
 namespace owl {
   

--- a/owl/Object.h
+++ b/owl/Object.h
@@ -79,6 +79,7 @@ namespace owl {
   /*! a object that belongs to a context */
   struct ContextObject : public Object {
     typedef std::shared_ptr<ContextObject> SP;
+    using DeviceData = Object::DeviceData;
     
     ContextObject(Context *const context)
       : context(context)

--- a/owl/RegisteredObject.h
+++ b/owl/RegisteredObject.h
@@ -4,7 +4,7 @@
 
 #pragma once
 
-#include "Object.h"
+#include "owl/Object.h"
 
 namespace owl {
 
@@ -16,7 +16,8 @@ namespace owl {
       sole job of this class is to properly register and unregister
       itself in the given registry when it gets created/destroyed */
   struct RegisteredObject : public ContextObject {
-
+    using DeviceData = ContextObject::DeviceData;
+    
     RegisteredObject(Context *const context,
                      ObjectRegistry &registry);
     ~RegisteredObject() override;


### PR DESCRIPTION
this fixes a compile issue where cuda 13.3 no longer allows accessing Parent::SomeNestedClass if that SomeNestedClass is itself inherited from a grandparent. Also bumps verison to 1.2.9 so parent projects can check for this patch.