### PR TITLE
Optixir fixes

### DIFF
--- a/owl/cmake/embed_optixir.cmake
+++ b/owl/cmake/embed_optixir.cmake
@@ -68,7 +68,7 @@ function(embed_optixir)
 
   ## Create command to run the bin2c via the CMake script ##
 
-  set(EMBED_OPTIXIR_C_FILE ${CMAKE_CURRENT_BINARY_DIR}/${EMBED_OPTIXIR_OUTPUT_TARGET}.c)
+  set(EMBED_OPTIXIR_C_FILE ${CMAKE_CURRENT_BINARY_DIR}/${EMBED_OPTIXIR_OUTPUT_TARGET}.cpp)
   get_filename_component(OUTPUT_FILE_NAME ${EMBED_OPTIXIR_C_FILE} NAME)
   add_custom_command(
     OUTPUT ${EMBED_OPTIXIR_C_FILE}
@@ -83,6 +83,11 @@ function(embed_optixir)
     COMMENT "Generating embedded OPTIXIR file: ${OUTPUT_FILE_NAME}"
   )
 
-  add_library(${EMBED_OPTIXIR_OUTPUT_TARGET} OBJECT)
+  add_library(${EMBED_OPTIXIR_OUTPUT_TARGET} STATIC)
   target_sources(${EMBED_OPTIXIR_OUTPUT_TARGET} PRIVATE ${EMBED_OPTIXIR_C_FILE})
+  set_target_properties(${EMBED_OPTIXIR_OUTPUT_TARGET} 
+    PROPERTIES 
+    CXX_VISIBILITY_PRESET default
+    CUDA_VISIBILITY_PRESET default
+  )
 endfunction()

--- a/owl/cmake/run_bin2c.cmake
+++ b/owl/cmake/run_bin2c.cmake
@@ -57,7 +57,7 @@ message("embed-ptx_run obj=${obj} -> dir ${obj_dir}")
     endif()
 
     # Append length 
-    string(APPEND file_contents "const uint32_t ${obj_name}_length = ${numBytes};\n\n")
+    string(APPEND file_contents "extern \"C\" const uint32_t ${obj_name}_length = ${numBytes};\n\n")
   endif()
 endforeach()
 


### PR DESCRIPTION
Hi,
I was trying to transition from PTX to optixir in my OWL application and ran into some issues getting optixir to work.

This patch fixes those issues by broadly copying what embed_ptx does, but applying it to embed_optixir.
Mainly changing the file extension of the generated file, and harmonising the add_library call and adding the set_target_properties calls.

I'm not too familiar with all this PTX/OPTIXIR stuff and not great with cmake, so I've probably gone wrong somewhere.
It does now work on my machine...

Lewis